### PR TITLE
Remove warnings on OTP 24

### DIFF
--- a/lib/uni_pg/pg2.ex
+++ b/lib/uni_pg/pg2.ex
@@ -1,60 +1,62 @@
-defmodule UniPg.Pg2 do
-  def start_link(_scope) do
-    {:ok, spawn_link(Process, :sleep, [:infinity])}
-  end
-
-  def join(scope, group, pids) when is_list(pids) do
-    ensure_group_created(scope, group)
-
-    pids
-    |> Enum.each(fn pid ->
-      :pg2.join({scope, group}, pid)
-    end)
-
-    :ok
-  end
-
-  def leave(scope, group, pids) when is_list(pids) do
-    ensure_group_created(scope, group)
-
-    pids
-    |> Enum.each(fn pid ->
-      :pg2.leave({scope, group}, pid)
-    end)
-
-    :ok
-  end
-
-  def get_local_members(scope, group) do
-    ensure_group_created(scope, group)
-    :pg2.get_local_members(namespace(scope, group))
-  end
-
-  def get_members(scope, group) do
-    ensure_group_created(scope, group)
-    :pg2.get_members(namespace(scope, group))
-  end
-
-  def which_groups(scope) do
-    ensure_started()
-
-    for [group] <- :ets.match(:pg2_table, {{:group, {scope, :"$1"}}}) do
-      group
+if System.otp_release() |> String.to_integer() < 24 do
+  defmodule UniPg.Pg2 do
+    def start_link(_scope) do
+      {:ok, spawn_link(Process, :sleep, [:infinity])}
     end
+
+    def join(scope, group, pids) when is_list(pids) do
+      ensure_group_created(scope, group)
+
+      pids
+      |> Enum.each(fn pid ->
+        :pg2.join({scope, group}, pid)
+      end)
+
+      :ok
+    end
+
+    def leave(scope, group, pids) when is_list(pids) do
+      ensure_group_created(scope, group)
+
+      pids
+      |> Enum.each(fn pid ->
+        :pg2.leave({scope, group}, pid)
+      end)
+
+      :ok
+    end
+
+    def get_local_members(scope, group) do
+      ensure_group_created(scope, group)
+      :pg2.get_local_members(namespace(scope, group))
+    end
+
+    def get_members(scope, group) do
+      ensure_group_created(scope, group)
+      :pg2.get_members(namespace(scope, group))
+    end
+
+    def which_groups(scope) do
+      ensure_started()
+
+      for [group] <- :ets.match(:pg2_table, {{:group, {scope, :"$1"}}}) do
+        group
+      end
+    end
+
+    # Utils
+
+    defp ensure_started() do
+      # Duplicated :pg2.start_link() has no effect and takes only 5us.
+      :pg2.start()
+    end
+
+    defp ensure_group_created(scope, group) do
+      ensure_started()
+      # Duplicated :pg2.create() has no effect and takes only 5us.
+      :pg2.create(namespace(scope, group))
+    end
+
+    defp namespace(scope, group), do: {scope, group}
   end
-
-  # Utils
-
-  defp ensure_started() do
-    # Duplicated :pg2.start_link() has no effect and takes only 5us.
-    :pg2.start()
-  end
-
-  defp ensure_group_created(scope, group) do
-    ensure_started()
-    # Duplicated :pg2.create() has no effect and takes only 5us.
-    :pg2.create(namespace(scope, group))
-  end
-
-  defp namespace(scope, group), do: {scope, group}
 end


### PR DESCRIPTION
To remove warnings below, don't compile `UniPG.Pg2` if OTP version is >= 24

```
Compiling 1 file (.ex)
warning: :pg2.create/1 is undefined or private, this module was removed in OTP 24. Use 'pg' instead
  lib/uni_pg/pg2.ex:57: UniPg.Pg2.ensure_group_created/2

warning: :pg2.get_local_members/1 is undefined or private, this module was removed in OTP 24. Use 'pg' instead
  lib/uni_pg/pg2.ex:31: UniPg.Pg2.get_local_members/2

warning: :pg2.get_members/1 is undefined or private, this module was removed in OTP 24. Use 'pg' instead
  lib/uni_pg/pg2.ex:36: UniPg.Pg2.get_members/2

warning: :pg2.join/2 is undefined or private, this module was removed in OTP 24. Use 'pg' instead
  lib/uni_pg/pg2.ex:12: UniPg.Pg2.join/3

warning: :pg2.leave/2 is undefined or private, this module was removed in OTP 24. Use 'pg' instead
  lib/uni_pg/pg2.ex:23: UniPg.Pg2.leave/3

warning: :pg2.start/0 is undefined or private, this module was removed in OTP 24. Use 'pg' instead
  lib/uni_pg/pg2.ex:51: UniPg.Pg2.ensure_started/0
```